### PR TITLE
fix: improve null handling for relatedEntities and data in Event cons…

### DIFF
--- a/domain/src/main/java/com/callv2/eventhub/domain/event/Event.java
+++ b/domain/src/main/java/com/callv2/eventhub/domain/event/Event.java
@@ -1,6 +1,10 @@
 package com.callv2.eventhub.domain.event;
 
+import static java.util.Objects.nonNull;
+
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,8 +34,8 @@ public class Event extends AggregateRoot<EventID> {
         this.source = source;
         this.occurredAt = occurredAt;
         this.ingestedAt = ingestedAt;
-        this.relatedEntities = relatedEntities == null ? Set.of() : Set.copyOf(relatedEntities);
-        this.data = data == null ? Map.of() : Map.copyOf(data);
+        this.relatedEntities = nonNull(relatedEntities) ? new HashSet<>(relatedEntities) : new HashSet<>();
+        this.data = nonNull(data) ? new HashMap<>(data) : new HashMap<>();
     }
 
     @Override
@@ -124,7 +128,7 @@ public class Event extends AggregateRoot<EventID> {
     }
 
     public Map<String, Object> getData() {
-        return data;
+        return new HashMap<>(data);
     }
 
 }


### PR DESCRIPTION
This pull request updates the `Event` class in the domain layer to improve how mutable collections are handled and to ensure safer data access patterns. The main changes focus on using mutable collection types for internal state and returning defensive copies to prevent unintended external modifications.

**Improvements to collection handling and data safety:**

* Changed internal storage of `relatedEntities` and `data` to use mutable `HashSet` and `HashMap` instead of immutable collections, ensuring proper mutability within the `Event` object.
* Updated the `getData()` method to return a defensive copy of the internal `data` map, preventing callers from modifying the internal state.

**Code style and imports:**

* Added static import for `Objects.nonNull` to simplify null checks in the constructor.